### PR TITLE
add external 3d model importer

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -1,0 +1,77 @@
+import bpy
+import os
+import sys
+import importlib
+import pathlib
+
+
+def import_fbx_files(list_of_files, collection_name):
+	# create collection for all attributes of this type 
+	bpy.ops.collection.create(name=collection_name)
+	
+	# link this collection to scene root (eg. rootCol -> coneCol)
+	bpy.context.scene.collection.children.link(bpy.data.collections[collection_name])
+	
+	index = 0    
+	for file in list_of_files:  	  
+		index = index + 1
+		# create collection for every attribute variation (eg. coneWhite_1_0)
+		obj_col_name = file[:-4] + "_" + str(index) + "_" #+ str(probability)
+		bpy.ops.collection.create(name=obj_col_name)
+		
+		# link collection to current attribute collection
+		bpy.data.collections[collection_name].children.link(bpy.data.collections[obj_col_name])
+		
+		# import .fbx file
+		bpy.ops.import_scene.fbx(filepath=os.getcwd() + "\\" + file)   
+		
+		# get all selected objs (objs are auto selected after import)
+		objs = (bpy.context.selected_objects)
+		
+		# rename object to filename (remove .fbx file ending)
+		objs[0].name = file[:-4]
+		
+		# link object to corresponding collection (eg. coneWhite_1_0)
+		bpy.context.scene.collection.objects.unlink(objs[0])
+		bpy.data.collections[obj_col_name].objects.link(objs[0])		
+		
+		# make sure last imported object is no longer selected
+		bpy.ops.object.select_all(action="DESELECT")  
+		
+def run():
+
+	
+	# Go to folder where models are stored (<.blend-file>\\3D_Model_Input)
+	model_dir = os.chdir(os.getcwd() + "\\3D_Model_Input")
+	
+	# Save directory location of (<.blend-file>\\3D_Model_Input)
+	top_level_dir = os.getcwd()
+	
+	# Get every subdirectory of current directory (<.blend-file>\\3D_Model_Input\\[Cone, Sphere, ....])
+	directory_contents = os.listdir(os.getcwd())
+	
+	# Go through every model-dir ([Cone, Sphere,...])
+	for directory in directory_contents:
+
+		# make sure we are in <.blend-file>\\3D_Model_Input
+		os.chdir(top_level_dir)
+
+		# exclude files (eg. .gitignore etc.)
+		if os.path.isdir(directory):
+			
+			# go into model directory eg. <.blend-file>\\3D_Model_Input\\Cone
+			os.chdir(os.getcwd()+"\\"+directory)
+			
+			# get all files contained in eg. <.blend-file>\\3D_Model_Input\\Cone
+			list_of_files = os.listdir(os.getcwd())
+
+			# directory should always be the name of the attribute
+			import_fbx_files(list_of_files, directory)
+		
+	
+if __name__ == '__main__':
+	# Make sure we are in correct starting directory (dir of this .blend file)
+	os.chdir(pathlib.Path(__file__).parent.resolve().parent.resolve())
+	
+	# run importer prog
+	run()


### PR DESCRIPTION
Hi,
sorry for the long wait.
This is a PR for #41 (Enable rarity for external 3d Models)

the import.py script imports models from the 3D_Model_Input folder into a blender file. The file and folder structure remains the same as outlined in the .readme.

One change is that every file needs to have a postfix with the rarity. A postfix for the index is not needed as it is added automatically. (eg. cone_10.fbx for a cone with a rarity of 10%).

This script currently only works on windows due to the way the file structure is navigated.
At the moment only .fbx files can be imported but adding additional formats should be trivial as long as they support global positioning of objects.

For this to work, you have to import and run this script manually before importing and running the main script.

Hope this is a good starting point.