### PR TITLE
Fixed a bug in material selection

### DIFF
--- a/main/material_generator.py
+++ b/main/material_generator.py
@@ -119,7 +119,10 @@ def apply_materials(hierarchy, single_dna, materials_file, enable_rarity):
                 material_name, material_list, = select_material(materials_file[b]['Material List'], b, enable_rarity)
 
                 # Gets the Order Number of the Material
-                material_order_num = list(material_list.keys()).index(material_name)
+				# We add 1 to the index because 0 is what we return on an invalid lookup. 
+				# If we don't add 1 then when material index 0 is chosen randomly we will not change materials, 
+				# and conversly the last material in the list will never show up
+                material_order_num = (list(material_list.keys()).index(material_name))+1
 
                 deconstructed_material_dna[a] = str(material_order_num)
                 complete = True


### PR DESCRIPTION
### Fixes #145 #

Previously the addon would never choose the last material in a material list, and would not change the material if the first in the list was chosen randomly.
This was caused by a missing "+1" because the original author chose 0 as an error when returned. Without the +1 the script could return 0 randomly when choosing a random element from the list